### PR TITLE
Develop Member.Index API

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -43,13 +43,41 @@ const docTemplate = `{
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/controller.Error"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/controller.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/members": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Members"
+                ],
+                "summary": "Index",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.Member"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.Error"
                         }
                     }
                 }
@@ -57,6 +85,17 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "controller.Error": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "integer"
+                }
+            }
+        },
         "domain.EmploymentStatus": {
             "type": "object",
             "properties": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -32,13 +32,41 @@
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/controller.Error"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/controller.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/members": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Members"
+                ],
+                "summary": "Index",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.Member"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.Error"
                         }
                     }
                 }
@@ -46,6 +74,17 @@
         }
     },
     "definitions": {
+        "controller.Error": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "integer"
+                }
+            }
+        },
         "domain.EmploymentStatus": {
             "type": "object",
             "properties": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,11 @@
 definitions:
+  controller.Error:
+    properties:
+      message:
+        type: string
+      status:
+        type: integer
+    type: object
   domain.EmploymentStatus:
     properties:
       createdAt:
@@ -91,12 +98,30 @@ paths:
         "404":
           description: Not Found
           schema:
-            type: string
+            $ref: '#/definitions/controller.Error'
         "500":
           description: Internal Server Error
           schema:
-            type: string
+            $ref: '#/definitions/controller.Error'
       summary: Show
       tags:
       - Member
+  /api/members:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/domain.Member'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controller.Error'
+      summary: Index
+      tags:
+      - Members
 swagger: "2.0"

--- a/infrastructure/router.go
+++ b/infrastructure/router.go
@@ -23,6 +23,7 @@ func init() {
 	e.Use(middleware.Recover())
 	memberController := controller.NewMemberController(InitDB())
 
+	e.GET("/api/members", memberController.Index)
 	e.GET("/api/members/:id", memberController.Show)
 	e.GET("/swagger/*", echoSwagger.WrapHandler)
 

--- a/interfaces/controller/member_controller.go
+++ b/interfaces/controller/member_controller.go
@@ -23,14 +23,31 @@ func NewMemberController(db database.DBHandler) *MemberController {
 	}
 }
 
+// Index godoc
+// @Summary  Index
+// @Tags     Members
+// @Produce  json
+// @Success 200 {array} domain.Member
+// @Failure 500 {object} Error
+// @Router   /api/members [get]
+func (controller *MemberController) Index(c echo.Context) error {
+	members, err := controller.MemberInteractor.GetMembers()
+	if err != nil {
+		c.JSON(500, NewError(500, err))
+		return nil
+	}
+	c.JSON(200, members)
+	return nil
+}
+
 // Show godoc
 // @Summary  Show
 // @Tags     Member
 // @Produce  json
 // @Param id path string true "ID"
 // @Success 200 {object} domain.Member
-// @Failure 404 {string} string
-// @Failure 500 {string} string
+// @Failure 404 {object} Error
+// @Failure 500 {object} Error
 // @Router   /api/members/{id} [get]
 func (controller *MemberController) Show(c echo.Context) error {
 	member, err := controller.MemberInteractor.GetMemberById(c.Param("id"))

--- a/interfaces/database/member_repository.go
+++ b/interfaces/database/member_repository.go
@@ -8,9 +8,16 @@ type MemberRepository struct {
 	DBHandler
 }
 
+func (repo *MemberRepository) FindAll() (members []domain.Member, err error) {
+	if err = repo.Joins("EmploymentStatus").Joins("Status").Find(&members).Error; err != nil {
+		return members, err
+	}
+	return members, nil
+}
+
 func (repo *MemberRepository) FindById(id string) (member domain.Member, err error) {
 	if err = repo.Joins("EmploymentStatus").Joins("Status").First(&member, id).Error; err != nil {
 		return member, err
 	}
-	return member, err
+	return member, nil
 }

--- a/usecase/member_interactor.go
+++ b/usecase/member_interactor.go
@@ -6,6 +6,11 @@ type MemberInteractor struct {
 	MemberRepository
 }
 
+func (interactor *MemberInteractor) GetMembers() ([]domain.Member, error) {
+	members, err := interactor.FindAll()
+	return members, err
+}
+
 func (interactor *MemberInteractor) GetMemberById(id string) (domain.Member, error) {
 	member, err := interactor.FindById(id)
 	return member, err

--- a/usecase/member_repository.go
+++ b/usecase/member_repository.go
@@ -4,4 +4,5 @@ import "emoshu_practice/domain"
 
 type MemberRepository interface {
 	FindById(id string) (domain.Member, error)
+	FindAll() ([]domain.Member, error)
 }


### PR DESCRIPTION
## やったこと
・社員情報一覧API作成

## 動作確認
### 社員情報一覧API
- READMEにしたがってcontainerを建てる
- READMEに従って初期データを挿入
- http://localhost:3000/api/members にアクセス
  - [ ] ↓の画像のようにテーブル結合された社員リストがレスポンスされる
 

![スクリーンショット 2023-02-16 16 22 28](https://user-images.githubusercontent.com/125238522/219295708-ca654bf2-773e-420e-a243-87a7b6408888.png)

