### PR TITLE
Develop Member.Create API,  Member.Update API and Member.Delete API

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -247,6 +247,38 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "delete": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Member"
+                ],
+                "summary": "Delete",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.Member"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.Error"
+                        }
+                    }
+                }
             }
         }
     },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -85,13 +85,6 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "type": "string",
-                        "description": "Emoployment End Date",
-                        "name": "end_date",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
                         "type": "integer",
                         "description": "Employment Status",
                         "name": "employment_status_id",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15,7 +15,33 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
-        "/api/member": {
+        "/api/members": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Members"
+                ],
+                "summary": "Index",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.Member"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.Error"
+                        }
+                    }
+                }
+            },
             "post": {
                 "produces": [
                     "application/json"
@@ -94,7 +120,45 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/member/{id}": {
+        "/api/members/{id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Member"
+                ],
+                "summary": "Show",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.Member"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controller.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.Error"
+                        }
+                    }
+                }
+            },
             "put": {
                 "produces": [
                     "application/json"
@@ -167,74 +231,6 @@ const docTemplate = `{
                 "responses": {
                     "201": {
                         "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/domain.Member"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/controller.Error"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/controller.Error"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/members": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Members"
-                ],
-                "summary": "Index",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/domain.Member"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/controller.Error"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/members/{id}": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Member"
-                ],
-                "summary": "Show",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/domain.Member"
                         }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -85,6 +85,12 @@ const docTemplate = `{
                         "required": true
                     },
                     {
+                        "type": "string",
+                        "description": "Emoployment End Date",
+                        "name": "end_date",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "description": "Employment Status",
                         "name": "employment_status_id",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -94,6 +94,98 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/member/{id}": {
+            "put": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Member"
+                ],
+                "summary": "Update",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Employee Number",
+                        "name": "no",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Full Name",
+                        "name": "full_name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Profile Image",
+                        "name": "profile_img",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kana Name",
+                        "name": "kana_name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Employment Start Date",
+                        "name": "start_date",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Emoployment End Date",
+                        "name": "end_date",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Employment Status",
+                        "name": "employment_status_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Status",
+                        "name": "status_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.Member"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controller.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/api/members": {
             "get": {
                 "produces": [

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15,6 +15,113 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/api/member": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Member"
+                ],
+                "summary": "Create",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Employee Number",
+                        "name": "no",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Full Name",
+                        "name": "full_name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Profile Image",
+                        "name": "profile_img",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kana Name",
+                        "name": "kana_name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Employment Start Date",
+                        "name": "start_date",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Emoployment End Date",
+                        "name": "end_date",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Employment Status",
+                        "name": "employment_status_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Status",
+                        "name": "status_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.Member"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/members": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Members"
+                ],
+                "summary": "Index",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.Member"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/api/members/{id}": {
             "get": {
                 "produces": [
@@ -54,34 +161,6 @@ const docTemplate = `{
                     }
                 }
             }
-        },
-        "/api/members": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Members"
-                ],
-                "summary": "Index",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/domain.Member"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/controller.Error"
-                        }
-                    }
-                }
-            }
         }
     },
     "definitions": {
@@ -99,19 +178,16 @@ const docTemplate = `{
         "domain.EmploymentStatus": {
             "type": "object",
             "properties": {
-                "createdAt": {
+                "created_at": {
                     "type": "string"
                 },
-                "deletedAt": {
-                    "$ref": "#/definitions/gorm.DeletedAt"
-                },
-                "employmentStatus": {
+                "employment_status": {
                     "type": "string"
                 },
                 "id": {
                     "type": "integer"
                 },
-                "updatedAt": {
+                "updated_at": {
                     "type": "string"
                 }
             }
@@ -122,28 +198,25 @@ const docTemplate = `{
                 "biography": {
                     "type": "string"
                 },
-                "createdAt": {
+                "created_at": {
                     "type": "string"
                 },
-                "deletedAt": {
-                    "$ref": "#/definitions/gorm.DeletedAt"
-                },
-                "employmentStatus": {
+                "employment_status": {
                     "$ref": "#/definitions/domain.EmploymentStatus"
                 },
-                "employmentStatusID": {
+                "employment_status_id": {
                     "type": "integer"
                 },
-                "endDate": {
+                "end_date": {
                     "type": "string"
                 },
-                "fullName": {
+                "full_name": {
                     "type": "string"
                 },
                 "id": {
                     "type": "integer"
                 },
-                "kanaName": {
+                "kana_name": {
                     "type": "string"
                 },
                 "motto": {
@@ -152,19 +225,19 @@ const docTemplate = `{
                 "no": {
                     "type": "string"
                 },
-                "profileImg": {
+                "profile_img": {
                     "type": "string"
                 },
-                "startDate": {
+                "start_date": {
                     "type": "string"
                 },
                 "status": {
                     "$ref": "#/definitions/domain.Status"
                 },
-                "statusID": {
+                "status_id": {
                     "type": "integer"
                 },
-                "updatedAt": {
+                "updated_at": {
                     "type": "string"
                 }
             }
@@ -172,11 +245,8 @@ const docTemplate = `{
         "domain.Status": {
             "type": "object",
             "properties": {
-                "createdAt": {
+                "created_at": {
                     "type": "string"
-                },
-                "deletedAt": {
-                    "$ref": "#/definitions/gorm.DeletedAt"
                 },
                 "id": {
                     "type": "integer"
@@ -184,20 +254,8 @@ const docTemplate = `{
                 "status": {
                     "type": "string"
                 },
-                "updatedAt": {
+                "updated_at": {
                     "type": "string"
-                }
-            }
-        },
-        "gorm.DeletedAt": {
-            "type": "object",
-            "properties": {
-                "time": {
-                    "type": "string"
-                },
-                "valid": {
-                    "description": "Valid is true if Time is not NULL",
-                    "type": "boolean"
                 }
             }
         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4,6 +4,113 @@
         "contact": {}
     },
     "paths": {
+        "/api/member": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Member"
+                ],
+                "summary": "Create",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Employee Number",
+                        "name": "no",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Full Name",
+                        "name": "full_name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Profile Image",
+                        "name": "profile_img",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kana Name",
+                        "name": "kana_name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Employment Start Date",
+                        "name": "start_date",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Emoployment End Date",
+                        "name": "end_date",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Employment Status",
+                        "name": "employment_status_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Status",
+                        "name": "status_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.Member"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/members": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Members"
+                ],
+                "summary": "Index",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.Member"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/api/members/{id}": {
             "get": {
                 "produces": [
@@ -43,34 +150,6 @@
                     }
                 }
             }
-        },
-        "/api/members": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Members"
-                ],
-                "summary": "Index",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/domain.Member"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/controller.Error"
-                        }
-                    }
-                }
-            }
         }
     },
     "definitions": {
@@ -88,19 +167,16 @@
         "domain.EmploymentStatus": {
             "type": "object",
             "properties": {
-                "createdAt": {
+                "created_at": {
                     "type": "string"
                 },
-                "deletedAt": {
-                    "$ref": "#/definitions/gorm.DeletedAt"
-                },
-                "employmentStatus": {
+                "employment_status": {
                     "type": "string"
                 },
                 "id": {
                     "type": "integer"
                 },
-                "updatedAt": {
+                "updated_at": {
                     "type": "string"
                 }
             }
@@ -111,28 +187,25 @@
                 "biography": {
                     "type": "string"
                 },
-                "createdAt": {
+                "created_at": {
                     "type": "string"
                 },
-                "deletedAt": {
-                    "$ref": "#/definitions/gorm.DeletedAt"
-                },
-                "employmentStatus": {
+                "employment_status": {
                     "$ref": "#/definitions/domain.EmploymentStatus"
                 },
-                "employmentStatusID": {
+                "employment_status_id": {
                     "type": "integer"
                 },
-                "endDate": {
+                "end_date": {
                     "type": "string"
                 },
-                "fullName": {
+                "full_name": {
                     "type": "string"
                 },
                 "id": {
                     "type": "integer"
                 },
-                "kanaName": {
+                "kana_name": {
                     "type": "string"
                 },
                 "motto": {
@@ -141,19 +214,19 @@
                 "no": {
                     "type": "string"
                 },
-                "profileImg": {
+                "profile_img": {
                     "type": "string"
                 },
-                "startDate": {
+                "start_date": {
                     "type": "string"
                 },
                 "status": {
                     "$ref": "#/definitions/domain.Status"
                 },
-                "statusID": {
+                "status_id": {
                     "type": "integer"
                 },
-                "updatedAt": {
+                "updated_at": {
                     "type": "string"
                 }
             }
@@ -161,11 +234,8 @@
         "domain.Status": {
             "type": "object",
             "properties": {
-                "createdAt": {
+                "created_at": {
                     "type": "string"
-                },
-                "deletedAt": {
-                    "$ref": "#/definitions/gorm.DeletedAt"
                 },
                 "id": {
                     "type": "integer"
@@ -173,20 +243,8 @@
                 "status": {
                     "type": "string"
                 },
-                "updatedAt": {
+                "updated_at": {
                     "type": "string"
-                }
-            }
-        },
-        "gorm.DeletedAt": {
-            "type": "object",
-            "properties": {
-                "time": {
-                    "type": "string"
-                },
-                "valid": {
-                    "description": "Valid is true if Time is not NULL",
-                    "type": "boolean"
                 }
             }
         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -74,6 +74,12 @@
                         "required": true
                     },
                     {
+                        "type": "string",
+                        "description": "Emoployment End Date",
+                        "name": "end_date",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "description": "Employment Status",
                         "name": "employment_status_id",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4,7 +4,33 @@
         "contact": {}
     },
     "paths": {
-        "/api/member": {
+        "/api/members": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Members"
+                ],
+                "summary": "Index",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.Member"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.Error"
+                        }
+                    }
+                }
+            },
             "post": {
                 "produces": [
                     "application/json"
@@ -83,7 +109,45 @@
                 }
             }
         },
-        "/api/member/{id}": {
+        "/api/members/{id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Member"
+                ],
+                "summary": "Show",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.Member"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controller.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.Error"
+                        }
+                    }
+                }
+            },
             "put": {
                 "produces": [
                     "application/json"
@@ -156,74 +220,6 @@
                 "responses": {
                     "201": {
                         "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/domain.Member"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/controller.Error"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/controller.Error"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/members": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Members"
-                ],
-                "summary": "Index",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/domain.Member"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/controller.Error"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/members/{id}": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Member"
-                ],
-                "summary": "Show",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/domain.Member"
                         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -236,6 +236,38 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Member"
+                ],
+                "summary": "Delete",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.Member"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.Error"
+                        }
+                    }
+                }
             }
         }
     },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -83,6 +83,98 @@
                 }
             }
         },
+        "/api/member/{id}": {
+            "put": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Member"
+                ],
+                "summary": "Update",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Employee Number",
+                        "name": "no",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Full Name",
+                        "name": "full_name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Profile Image",
+                        "name": "profile_img",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kana Name",
+                        "name": "kana_name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Employment Start Date",
+                        "name": "start_date",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Emoployment End Date",
+                        "name": "end_date",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Employment Status",
+                        "name": "employment_status_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Status",
+                        "name": "status_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.Member"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controller.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/api/members": {
             "get": {
                 "produces": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -74,13 +74,6 @@
                         "required": true
                     },
                     {
-                        "type": "string",
-                        "description": "Emoployment End Date",
-                        "name": "end_date",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
                         "type": "integer",
                         "description": "Employment Status",
                         "name": "employment_status_id",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -136,6 +136,27 @@ paths:
       tags:
       - Member
   /api/members/{id}:
+    delete:
+      parameters:
+      - description: ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/domain.Member'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controller.Error'
+      summary: Delete
+      tags:
+      - Member
     get:
       parameters:
       - description: ID

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -109,6 +109,10 @@ paths:
         name: start_date
         required: true
         type: string
+      - description: Emoployment End Date
+        in: query
+        name: end_date
+        type: string
       - description: Employment Status
         in: query
         name: employment_status_id

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -8,78 +8,133 @@ definitions:
     type: object
   domain.EmploymentStatus:
     properties:
-      createdAt:
+      created_at:
         type: string
-      deletedAt:
-        $ref: '#/definitions/gorm.DeletedAt'
-      employmentStatus:
+      employment_status:
         type: string
       id:
         type: integer
-      updatedAt:
+      updated_at:
         type: string
     type: object
   domain.Member:
     properties:
       biography:
         type: string
-      createdAt:
+      created_at:
         type: string
-      deletedAt:
-        $ref: '#/definitions/gorm.DeletedAt'
-      employmentStatus:
+      employment_status:
         $ref: '#/definitions/domain.EmploymentStatus'
-      employmentStatusID:
+      employment_status_id:
         type: integer
-      endDate:
+      end_date:
         type: string
-      fullName:
+      full_name:
         type: string
       id:
         type: integer
-      kanaName:
+      kana_name:
         type: string
       motto:
         type: string
       "no":
         type: string
-      profileImg:
+      profile_img:
         type: string
-      startDate:
+      start_date:
         type: string
       status:
         $ref: '#/definitions/domain.Status'
-      statusID:
+      status_id:
         type: integer
-      updatedAt:
+      updated_at:
         type: string
     type: object
   domain.Status:
     properties:
-      createdAt:
+      created_at:
         type: string
-      deletedAt:
-        $ref: '#/definitions/gorm.DeletedAt'
       id:
         type: integer
       status:
         type: string
-      updatedAt:
+      updated_at:
         type: string
-    type: object
-  gorm.DeletedAt:
-    properties:
-      time:
-        type: string
-      valid:
-        description: Valid is true if Time is not NULL
-        type: boolean
     type: object
 info:
   contact: {}
-  title: EmoshU practice
-  version: "1.0"
 paths:
+  /api/member:
+    post:
+      parameters:
+      - description: Employee Number
+        in: query
+        name: "no"
+        required: true
+        type: string
+      - description: Full Name
+        in: query
+        name: full_name
+        type: string
+      - description: Profile Image
+        in: query
+        name: profile_img
+        required: true
+        type: string
+      - description: Kana Name
+        in: query
+        name: kana_name
+        type: string
+      - description: Employment Start Date
+        in: query
+        name: start_date
+        required: true
+        type: string
+      - description: Emoployment End Date
+        in: query
+        name: end_date
+        required: true
+        type: string
+      - description: Employment Status
+        in: query
+        name: employment_status_id
+        type: integer
+      - description: Status
+        in: query
+        name: status_id
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/domain.Member'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controller.Error'
+      summary: Create
+      tags:
+      - Member
+  /api/members:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/domain.Member'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controller.Error'
+      summary: Index
+      tags:
+      - Members
   /api/members/{id}:
     get:
       parameters:
@@ -106,22 +161,4 @@ paths:
       summary: Show
       tags:
       - Member
-  /api/members:
-    get:
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/domain.Member'
-            type: array
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/controller.Error'
-      summary: Index
-      tags:
-      - Members
 swagger: "2.0"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -63,6 +63,8 @@ definitions:
     type: object
 info:
   contact: {}
+  version: "1.0"
+  title: "emoshu practice"
 paths:
   /api/member:
     post:
@@ -115,6 +117,68 @@ paths:
           schema:
             $ref: '#/definitions/controller.Error'
       summary: Create
+      tags:
+      - Member
+  /api/member/{id}:
+    put:
+      parameters:
+      - description: ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Employee Number
+        in: query
+        name: "no"
+        required: true
+        type: string
+      - description: Full Name
+        in: query
+        name: full_name
+        type: string
+      - description: Profile Image
+        in: query
+        name: profile_img
+        required: true
+        type: string
+      - description: Kana Name
+        in: query
+        name: kana_name
+        type: string
+      - description: Employment Start Date
+        in: query
+        name: start_date
+        required: true
+        type: string
+      - description: Emoployment End Date
+        in: query
+        name: end_date
+        required: true
+        type: string
+      - description: Employment Status
+        in: query
+        name: employment_status_id
+        type: integer
+      - description: Status
+        in: query
+        name: status_id
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/domain.Member'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/controller.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controller.Error'
+      summary: Update
       tags:
       - Member
   /api/members:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -66,7 +66,24 @@ info:
   version: "1.0"
   title: "emoshu practice"
 paths:
-  /api/member:
+  /api/members:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/domain.Member'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controller.Error'
+      summary: Index
+      tags:
+      - Members
     post:
       parameters:
       - description: Employee Number
@@ -119,7 +136,32 @@ paths:
       summary: Create
       tags:
       - Member
-  /api/member/{id}:
+  /api/members/{id}:
+    get:
+      parameters:
+      - description: ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/domain.Member'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/controller.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controller.Error'
+      summary: Show
+      tags:
+      - Member
     put:
       parameters:
       - description: ID
@@ -179,50 +221,6 @@ paths:
           schema:
             $ref: '#/definitions/controller.Error'
       summary: Update
-      tags:
-      - Member
-  /api/members:
-    get:
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/domain.Member'
-            type: array
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/controller.Error'
-      summary: Index
-      tags:
-      - Members
-  /api/members/{id}:
-    get:
-      parameters:
-      - description: ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/domain.Member'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/controller.Error'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/controller.Error'
-      summary: Show
       tags:
       - Member
 swagger: "2.0"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -109,11 +109,6 @@ paths:
         name: start_date
         required: true
         type: string
-      - description: Emoployment End Date
-        in: query
-        name: end_date
-        required: true
-        type: string
       - description: Employment Status
         in: query
         name: employment_status_id

--- a/domain/department.go
+++ b/domain/department.go
@@ -1,8 +1,10 @@
 package domain
 
-import "gorm.io/gorm"
+import "time"
 
 type Department struct {
-	gorm.Model
-	Department string `gorm:"not null"`
+	ID         uint      `gorm:"primarykey" json:"id"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+	Department string    `gorm:"not null" json:"department"`
 }

--- a/domain/department.go
+++ b/domain/department.go
@@ -4,7 +4,7 @@ import "time"
 
 type Department struct {
 	ID         uint      `gorm:"primarykey" json:"id"`
-	CreatedAt  time.Time `json:"created_at"`
-	UpdatedAt  time.Time `json:"updated_at"`
+	CreatedAt  time.Time `gorm:"autoCreateTime:milli" json:"created_at"`
+	UpdatedAt  time.Time `gorm:"autoUpdateTime:milli" json:"updated_at"`
 	Department string    `gorm:"not null" json:"department"`
 }

--- a/domain/employment_status.go
+++ b/domain/employment_status.go
@@ -1,8 +1,10 @@
 package domain
 
-import "gorm.io/gorm"
+import "time"
 
 type EmploymentStatus struct {
-	gorm.Model
-	EmploymentStatus string `gorm:"not null"`
+	ID               uint      `gorm:"primarykey" json:"id"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+	EmploymentStatus string    `gorm:"not null" json:"employment_status"`
 }

--- a/domain/employment_status.go
+++ b/domain/employment_status.go
@@ -4,7 +4,7 @@ import "time"
 
 type EmploymentStatus struct {
 	ID               uint      `gorm:"primarykey" json:"id"`
-	CreatedAt        time.Time `json:"created_at"`
-	UpdatedAt        time.Time `json:"updated_at"`
+	CreatedAt        time.Time `gorm:"autoCreateTime:milli" json:"created_at"`
+	UpdatedAt        time.Time `gorm:"autoUpdateTime:milli" json:"updated_at"`
 	EmploymentStatus string    `gorm:"not null" json:"employment_status"`
 }

--- a/domain/member.go
+++ b/domain/member.go
@@ -2,22 +2,22 @@ package domain
 
 import (
 	"time"
-
-	"gorm.io/gorm"
 )
 
 type Member struct {
-	gorm.Model
-	No                 string
-	ProfileImg         string `gorm:"not null"`
-	FullName           string `gorm:"not null"`
-	KanaName           string
-	Motto              string
-	Biography          string
-	StartDate          time.Time
-	EndDate            time.Time
-	EmploymentStatusID uint
-	EmploymentStatus   EmploymentStatus
-	StatusID           uint
-	Status             Status
+	ID                 uint             `gorm:"primarykey" json:"id"`
+	CreatedAt          time.Time        `json:"created_at"`
+	UpdatedAt          time.Time        `json:"updated_at"`
+	No                 string           `json:"no"`
+	ProfileImg         string           `gorm:"not null" json:"profile_img"`
+	FullName           string           `gorm:"not null" json:"full_name"`
+	KanaName           string           `json:"kana_name"`
+	Motto              string           `json:"motto"`
+	Biography          string           `json:"biography"`
+	StartDate          time.Time        `json:"start_date"`
+	EndDate            time.Time        `json:"end_date"`
+	EmploymentStatusID uint             `json:"employment_status_id"`
+	EmploymentStatus   EmploymentStatus `json:"employment_status"`
+	StatusID           uint             `json:"status_id"`
+	Status             Status           `json:"status"`
 }

--- a/domain/member.go
+++ b/domain/member.go
@@ -15,7 +15,7 @@ type Member struct {
 	Motto              string           `json:"motto"`
 	Biography          string           `json:"biography"`
 	StartDate          time.Time        `json:"start_date"`
-	EndDate            time.Time        `json:"end_date"`
+	EndDate            *time.Time       `json:"end_date"`
 	EmploymentStatusID uint             `json:"employment_status_id"`
 	EmploymentStatus   EmploymentStatus `json:"employment_status"`
 	StatusID           uint             `json:"status_id"`

--- a/domain/member.go
+++ b/domain/member.go
@@ -6,8 +6,8 @@ import (
 
 type Member struct {
 	ID                 uint             `gorm:"primarykey" json:"id"`
-	CreatedAt          time.Time        `json:"created_at"`
-	UpdatedAt          time.Time        `json:"updated_at"`
+	CreatedAt          time.Time        `gorm:"autoCreateTime:milli" json:"created_at"`
+	UpdatedAt          time.Time        `gorm:"autoUpdateTime:milli" json:"updated_at"`
 	No                 string           `json:"no"`
 	ProfileImg         string           `gorm:"not null" json:"profile_img"`
 	FullName           string           `gorm:"not null" json:"full_name"`

--- a/domain/member_department.go
+++ b/domain/member_department.go
@@ -1,11 +1,13 @@
 package domain
 
-import "gorm.io/gorm"
+import "time"
 
 type MemberDepartment struct {
-	gorm.Model
-	MemberID     uint
-	Member       Member
-	DepartmentID uint
-	Department   Department
+	ID           uint       `gorm:"primarykey" json:"id"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
+	MemberID     uint       `json:"member_id"`
+	Member       Member     `json:"member"`
+	DepartmentID uint       `json:"department_id"`
+	Department   Department `json:"department"`
 }

--- a/domain/member_department.go
+++ b/domain/member_department.go
@@ -4,8 +4,8 @@ import "time"
 
 type MemberDepartment struct {
 	ID           uint       `gorm:"primarykey" json:"id"`
-	CreatedAt    time.Time  `json:"created_at"`
-	UpdatedAt    time.Time  `json:"updated_at"`
+	CreatedAt    time.Time  `gorm:"autoCreateTime:milli" json:"created_at"`
+	UpdatedAt    time.Time  `gorm:"autoUpdateTime:milli" json:"updated_at"`
 	MemberID     uint       `json:"member_id"`
 	Member       Member     `json:"member"`
 	DepartmentID uint       `json:"department_id"`

--- a/domain/member_role.go
+++ b/domain/member_role.go
@@ -1,11 +1,13 @@
 package domain
 
-import "gorm.io/gorm"
+import "time"
 
 type MemberRole struct {
-	gorm.Model
-	MemberID uint
-	Member   Member
-	RoleID   uint
-	Role     Role
+	ID        uint      `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	MemberID  uint      `json:"member_id"`
+	Member    Member    `json:"member"`
+	RoleID    uint      `json:"role_id"`
+	Role      Role      `json:"role"`
 }

--- a/domain/member_role.go
+++ b/domain/member_role.go
@@ -4,8 +4,8 @@ import "time"
 
 type MemberRole struct {
 	ID        uint      `gorm:"primarykey" json:"id"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	CreatedAt time.Time `gorm:"autoCreateTime:milli" json:"created_at"`
+	UpdatedAt time.Time `gorm:"autoUpdateTime:milli" json:"updated_at"`
 	MemberID  uint      `json:"member_id"`
 	Member    Member    `json:"member"`
 	RoleID    uint      `json:"role_id"`

--- a/domain/role.go
+++ b/domain/role.go
@@ -1,8 +1,10 @@
 package domain
 
-import "gorm.io/gorm"
+import "time"
 
 type Role struct {
-	gorm.Model
-	Role string `gorm:"not null"`
+	ID        uint      `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Role      string    `gorm:"not null" json:"role"`
 }

--- a/domain/role.go
+++ b/domain/role.go
@@ -4,7 +4,7 @@ import "time"
 
 type Role struct {
 	ID        uint      `gorm:"primarykey" json:"id"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	CreatedAt time.Time `gorm:"autoCreateTime:milli" json:"created_at"`
+	UpdatedAt time.Time `gorm:"autoUpdateTime:milli" json:"updated_at"`
 	Role      string    `gorm:"not null" json:"role"`
 }

--- a/domain/status.go
+++ b/domain/status.go
@@ -1,8 +1,10 @@
 package domain
 
-import "gorm.io/gorm"
+import "time"
 
 type Status struct {
-	gorm.Model
-	Status string `gorm:"not null"`
+	ID        uint      `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Status    string    `gorm:"not null" json:"status"`
 }

--- a/domain/status.go
+++ b/domain/status.go
@@ -4,7 +4,7 @@ import "time"
 
 type Status struct {
 	ID        uint      `gorm:"primarykey" json:"id"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	CreatedAt time.Time `gorm:"autoCreateTime:milli" json:"created_at"`
+	UpdatedAt time.Time `gorm:"autoUpdateTime:milli" json:"updated_at"`
 	Status    string    `gorm:"not null" json:"status"`
 }

--- a/infrastructure/router.go
+++ b/infrastructure/router.go
@@ -25,6 +25,8 @@ func init() {
 
 	e.GET("/api/members", memberController.Index)
 	e.GET("/api/members/:id", memberController.Show)
+	e.POST("/api/member", memberController.Create)
+	e.PUT("/api/member/:id", memberController.Update)
 	e.GET("/swagger/*", echoSwagger.WrapHandler)
 
 	e.Logger.Fatal(e.Start(":3000"))

--- a/infrastructure/router.go
+++ b/infrastructure/router.go
@@ -27,6 +27,7 @@ func init() {
 	e.GET("/api/members/:id", memberController.Show)
 	e.POST("/api/members", memberController.Create)
 	e.PUT("/api/members/:id", memberController.Update)
+	e.DELETE("/api/members/:id", memberController.Delete)
 	e.GET("/swagger/*", echoSwagger.WrapHandler)
 
 	e.Logger.Fatal(e.Start(":3000"))

--- a/infrastructure/router.go
+++ b/infrastructure/router.go
@@ -25,8 +25,8 @@ func init() {
 
 	e.GET("/api/members", memberController.Index)
 	e.GET("/api/members/:id", memberController.Show)
-	e.POST("/api/member", memberController.Create)
-	e.PUT("/api/member/:id", memberController.Update)
+	e.POST("/api/members", memberController.Create)
+	e.PUT("/api/members/:id", memberController.Update)
 	e.GET("/swagger/*", echoSwagger.WrapHandler)
 
 	e.Logger.Fatal(e.Start(":3000"))

--- a/interfaces/controller/member_controller.go
+++ b/interfaces/controller/member_controller.go
@@ -74,7 +74,6 @@ func (controller *MemberController) Show(c echo.Context) error {
 // @Param profile_img query string true "Profile Image"
 // @Param kana_name query string false "Kana Name"
 // @Param start_date query string true "Employment Start Date"
-// @Param end_date query string true "Emoployment End Date"
 // @Param employment_status_id query uint false "Employment Status"
 // @Param status_id query uint false "Status"
 // @Success 201 {object} domain.Member

--- a/interfaces/controller/member_controller.go
+++ b/interfaces/controller/member_controller.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"emoshu_practice/domain"
 	"emoshu_practice/interfaces/database"
 	"emoshu_practice/usecase"
 	"errors"
@@ -60,5 +61,34 @@ func (controller *MemberController) Show(c echo.Context) error {
 		return nil
 	}
 	c.JSON(200, member)
+	return nil
+}
+
+// Create godoc
+// @Summary  Create
+// @Tags     Member
+// @Produce  json
+// @Param no query string true "Employee Number"
+// @Param full_name query string false "Full Name"
+// @Param profile_img query string true "Profile Image"
+// @Param kana_name query string false "Kana Name"
+// @Param start_date query string true "Employment Start Date"
+// @Param end_date query string true "Emoployment End Date"
+// @Param employment_status_id query uint false "Employment Status"
+// @Param status_id query uint false "Status"
+// @Success 201 {object} domain.Member
+// @Failure 500 {object} Error
+// @Router   /api/member [post]
+func (controller *MemberController) Create(c echo.Context) error {
+	member := domain.Member{}
+	if err := c.Bind(&member); err != nil {
+		c.JSON(500, NewError(500, err))
+	}
+	err := controller.MemberInteractor.CreateMember(member)
+	if err != nil {
+		c.JSON(500, NewError(500, err))
+		return nil
+	}
+	c.JSON(201, member)
 	return nil
 }

--- a/interfaces/controller/member_controller.go
+++ b/interfaces/controller/member_controller.go
@@ -5,6 +5,7 @@ import (
 	"emoshu_practice/interfaces/database"
 	"emoshu_practice/usecase"
 	"errors"
+	"strconv"
 
 	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
@@ -86,6 +87,43 @@ func (controller *MemberController) Create(c echo.Context) error {
 	}
 	err := controller.MemberInteractor.CreateMember(member)
 	if err != nil {
+		c.JSON(500, NewError(500, err))
+		return nil
+	}
+	c.JSON(201, member)
+	return nil
+}
+
+// Update godoc
+// @Summary  Update
+// @Tags     Member
+// @Produce  json
+// @Param id path string true "ID"
+// @Param no query string true "Employee Number"
+// @Param full_name query string false "Full Name"
+// @Param profile_img query string true "Profile Image"
+// @Param kana_name query string false "Kana Name"
+// @Param start_date query string true "Employment Start Date"
+// @Param end_date query string true "Emoployment End Date"
+// @Param employment_status_id query uint false "Employment Status"
+// @Param status_id query uint false "Status"
+// @Success 201 {object} domain.Member
+// @Failure 404 {object} Error
+// @Failure 500 {object} Error
+// @Router   /api/member/{id} [put]
+func (controller *MemberController) Update(c echo.Context) error {
+	member := domain.Member{}
+	if err := c.Bind(&member); err != nil {
+		c.JSON(500, NewError(500, err))
+	}
+	memberId, _ := strconv.Atoi(c.Param("id"))
+	member.ID = uint(memberId)
+	err := controller.MemberInteractor.UpdateMember(member)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(404, NewError(404, err))
+			return nil
+		}
 		c.JSON(500, NewError(500, err))
 		return nil
 	}

--- a/interfaces/controller/member_controller.go
+++ b/interfaces/controller/member_controller.go
@@ -119,7 +119,8 @@ func (controller *MemberController) Update(c echo.Context) error {
 	}
 	memberId, _ := strconv.Atoi(c.Param("id"))
 	member.ID = uint(memberId)
-	err := controller.MemberInteractor.UpdateMember(member)
+	newMember, err := controller.MemberInteractor.UpdateMember(member)
+	member = newMember
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			c.JSON(404, NewError(404, err))

--- a/interfaces/controller/member_controller.go
+++ b/interfaces/controller/member_controller.go
@@ -132,3 +132,29 @@ func (controller *MemberController) Update(c echo.Context) error {
 	c.JSON(201, member)
 	return nil
 }
+
+// Delete godoc
+// @Summary  Delete
+// @Tags     Member
+// @Produce  json
+// @Param id path string true "ID"
+// @Success 200 {object} domain.Member
+// @Failure 500 {object} Error
+// @Router   /api/members/{id} [delete]
+func (controller *MemberController) Delete(c echo.Context) error {
+	memberId, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(500, NewError(500, err))
+		return nil
+	}
+	member := domain.Member{
+		ID: uint(memberId),
+	}
+	err = controller.MemberInteractor.DeleteMemberById(member)
+	if err != nil {
+		c.JSON(500, NewError(500, err))
+		return nil
+	}
+	c.JSON(200, member)
+	return nil
+}

--- a/interfaces/controller/member_controller.go
+++ b/interfaces/controller/member_controller.go
@@ -74,6 +74,7 @@ func (controller *MemberController) Show(c echo.Context) error {
 // @Param profile_img query string true "Profile Image"
 // @Param kana_name query string false "Kana Name"
 // @Param start_date query string true "Employment Start Date"
+// @Param end_date query string false "Emoployment End Date"
 // @Param employment_status_id query uint false "Employment Status"
 // @Param status_id query uint false "Status"
 // @Success 201 {object} domain.Member

--- a/interfaces/controller/member_controller.go
+++ b/interfaces/controller/member_controller.go
@@ -79,7 +79,7 @@ func (controller *MemberController) Show(c echo.Context) error {
 // @Param status_id query uint false "Status"
 // @Success 201 {object} domain.Member
 // @Failure 500 {object} Error
-// @Router   /api/member [post]
+// @Router   /api/members [post]
 func (controller *MemberController) Create(c echo.Context) error {
 	member := domain.Member{}
 	if err := c.Bind(&member); err != nil {
@@ -110,7 +110,7 @@ func (controller *MemberController) Create(c echo.Context) error {
 // @Success 201 {object} domain.Member
 // @Failure 404 {object} Error
 // @Failure 500 {object} Error
-// @Router   /api/member/{id} [put]
+// @Router   /api/members/{id} [put]
 func (controller *MemberController) Update(c echo.Context) error {
 	member := domain.Member{}
 	if err := c.Bind(&member); err != nil {

--- a/interfaces/controller/member_controller.go
+++ b/interfaces/controller/member_controller.go
@@ -85,7 +85,8 @@ func (controller *MemberController) Create(c echo.Context) error {
 	if err := c.Bind(&member); err != nil {
 		c.JSON(500, NewError(500, err))
 	}
-	err := controller.MemberInteractor.CreateMember(member)
+	newMember, err := controller.MemberInteractor.CreateMember(member)
+	member = newMember
 	if err != nil {
 		c.JSON(500, NewError(500, err))
 		return nil

--- a/interfaces/database/db_handler.go
+++ b/interfaces/database/db_handler.go
@@ -13,4 +13,5 @@ type DBHandler interface {
 	Model(interface{}) *gorm.DB
 	Updates(interface{}) *gorm.DB
 	Where(interface{}, ...interface{}) *gorm.DB
+	Delete(interface{}, ...interface{}) *gorm.DB
 }

--- a/interfaces/database/db_handler.go
+++ b/interfaces/database/db_handler.go
@@ -9,4 +9,8 @@ type DBHandler interface {
 	First(interface{}, ...interface{}) *gorm.DB
 	Joins(string, ...interface{}) *gorm.DB
 	Create(interface{}) *gorm.DB
+	Save(interface{}) *gorm.DB
+	Model(interface{}) *gorm.DB
+	Updates(interface{}) *gorm.DB
+	Where(interface{}, ...interface{}) *gorm.DB
 }

--- a/interfaces/database/db_handler.go
+++ b/interfaces/database/db_handler.go
@@ -8,4 +8,5 @@ type DBHandler interface {
 	Find(interface{}, ...interface{}) *gorm.DB
 	First(interface{}, ...interface{}) *gorm.DB
 	Joins(string, ...interface{}) *gorm.DB
+	Create(interface{}) *gorm.DB
 }

--- a/interfaces/database/member_repository.go
+++ b/interfaces/database/member_repository.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"emoshu_practice/domain"
+	"fmt"
 )
 
 type MemberRepository struct {
@@ -48,4 +49,14 @@ func (repo *MemberRepository) Update(m domain.Member) (domain.Member, error) {
 		return m, err
 	}
 	return m, nil
+}
+
+func (repo *MemberRepository) DeleteById(m domain.Member) error {
+	result := repo.Delete(&m)
+	if result.Error != nil {
+		return result.Error
+	} else if result.RowsAffected < 1 {
+		return fmt.Errorf("row with id=%d cannot be deleted because it doesn't exist", m.ID)
+	}
+	return nil
 }

--- a/interfaces/database/member_repository.go
+++ b/interfaces/database/member_repository.go
@@ -28,3 +28,21 @@ func (repo *MemberRepository) New(m domain.Member) (err error) {
 	}
 	return nil
 }
+
+func (repo *MemberRepository) Update(m domain.Member) (err error) {
+	if err = repo.Model(&domain.Member{}).Where("id = ?", m.ID).Updates(map[string]interface{}{
+		"No":                 m.No,
+		"ProfileImg":         m.ProfileImg,
+		"FullName":           m.FullName,
+		"KanaName":           m.KanaName,
+		"Motto":              m.Motto,
+		"Biography":          m.Biography,
+		"StartDate":          m.StartDate,
+		"EndDate":            m.EndDate,
+		"EmploymentStatusID": m.EmploymentStatusID,
+		"StatusID":           m.StatusID,
+	}).Error; err != nil {
+		return err
+	}
+	return nil
+}

--- a/interfaces/database/member_repository.go
+++ b/interfaces/database/member_repository.go
@@ -22,11 +22,11 @@ func (repo *MemberRepository) FindById(id string) (member domain.Member, err err
 	return member, nil
 }
 
-func (repo *MemberRepository) New(m domain.Member) (err error) {
-	if err = repo.Create(&m).Error; err != nil {
-		return err
+func (repo *MemberRepository) New(m domain.Member) (domain.Member, error) {
+	if err := repo.Create(&m).Error; err != nil {
+		return m, err
 	}
-	return nil
+	return m, nil
 }
 
 func (repo *MemberRepository) Update(m domain.Member) (err error) {

--- a/interfaces/database/member_repository.go
+++ b/interfaces/database/member_repository.go
@@ -29,8 +29,8 @@ func (repo *MemberRepository) New(m domain.Member) (domain.Member, error) {
 	return m, nil
 }
 
-func (repo *MemberRepository) Update(m domain.Member) (err error) {
-	if err = repo.Model(&domain.Member{}).Where("id = ?", m.ID).Updates(map[string]interface{}{
+func (repo *MemberRepository) Update(m domain.Member) (domain.Member, error) {
+	if err := repo.Model(&domain.Member{}).Where("id = ?", m.ID).Updates(map[string]interface{}{
 		"No":                 m.No,
 		"ProfileImg":         m.ProfileImg,
 		"FullName":           m.FullName,
@@ -42,7 +42,10 @@ func (repo *MemberRepository) Update(m domain.Member) (err error) {
 		"EmploymentStatusID": m.EmploymentStatusID,
 		"StatusID":           m.StatusID,
 	}).Error; err != nil {
-		return err
+		return m, err
 	}
-	return nil
+	if err := repo.Joins("EmploymentStatus").Joins("Status").First(&m, m.ID).Error; err != nil {
+		return m, err
+	}
+	return m, nil
 }

--- a/interfaces/database/member_repository.go
+++ b/interfaces/database/member_repository.go
@@ -21,3 +21,10 @@ func (repo *MemberRepository) FindById(id string) (member domain.Member, err err
 	}
 	return member, nil
 }
+
+func (repo *MemberRepository) New(m domain.Member) (err error) {
+	if err = repo.Create(&m).Error; err != nil {
+		return err
+	}
+	return nil
+}

--- a/usecase/member_interactor.go
+++ b/usecase/member_interactor.go
@@ -16,9 +16,9 @@ func (interactor *MemberInteractor) GetMemberById(id string) (domain.Member, err
 	return member, err
 }
 
-func (interactor *MemberInteractor) CreateMember(member domain.Member) error {
-	err := interactor.New(member)
-	return err
+func (interactor *MemberInteractor) CreateMember(member domain.Member) (domain.Member, error) {
+	member, err := interactor.New(member)
+	return member, err
 }
 
 func (interactor *MemberInteractor) UpdateMember(member domain.Member) error {

--- a/usecase/member_interactor.go
+++ b/usecase/member_interactor.go
@@ -21,7 +21,7 @@ func (interactor *MemberInteractor) CreateMember(member domain.Member) (domain.M
 	return member, err
 }
 
-func (interactor *MemberInteractor) UpdateMember(member domain.Member) error {
-	err := interactor.Update(member)
-	return err
+func (interactor *MemberInteractor) UpdateMember(member domain.Member) (domain.Member, error) {
+	member, err := interactor.Update(member)
+	return member, err
 }

--- a/usecase/member_interactor.go
+++ b/usecase/member_interactor.go
@@ -15,3 +15,8 @@ func (interactor *MemberInteractor) GetMemberById(id string) (domain.Member, err
 	member, err := interactor.FindById(id)
 	return member, err
 }
+
+func (interactor *MemberInteractor) CreateMember(member domain.Member) error {
+	err := interactor.New(member)
+	return err
+}

--- a/usecase/member_interactor.go
+++ b/usecase/member_interactor.go
@@ -20,3 +20,8 @@ func (interactor *MemberInteractor) CreateMember(member domain.Member) error {
 	err := interactor.New(member)
 	return err
 }
+
+func (interactor *MemberInteractor) UpdateMember(member domain.Member) error {
+	err := interactor.Update(member)
+	return err
+}

--- a/usecase/member_interactor.go
+++ b/usecase/member_interactor.go
@@ -25,3 +25,8 @@ func (interactor *MemberInteractor) UpdateMember(member domain.Member) (domain.M
 	member, err := interactor.Update(member)
 	return member, err
 }
+
+func (interactor *MemberInteractor) DeleteMemberById(member domain.Member) error {
+	err := interactor.MemberRepository.DeleteById(member)
+	return err
+}

--- a/usecase/member_repository.go
+++ b/usecase/member_repository.go
@@ -5,4 +5,5 @@ import "emoshu_practice/domain"
 type MemberRepository interface {
 	FindById(id string) (domain.Member, error)
 	FindAll() ([]domain.Member, error)
+	New(member domain.Member) error
 }

--- a/usecase/member_repository.go
+++ b/usecase/member_repository.go
@@ -7,4 +7,5 @@ type MemberRepository interface {
 	FindAll() ([]domain.Member, error)
 	New(member domain.Member) (domain.Member, error)
 	Update(member domain.Member) (domain.Member, error)
+	DeleteById(domain.Member) error
 }

--- a/usecase/member_repository.go
+++ b/usecase/member_repository.go
@@ -6,5 +6,5 @@ type MemberRepository interface {
 	FindById(id string) (domain.Member, error)
 	FindAll() ([]domain.Member, error)
 	New(member domain.Member) (domain.Member, error)
-	Update(member domain.Member) error
+	Update(member domain.Member) (domain.Member, error)
 }

--- a/usecase/member_repository.go
+++ b/usecase/member_repository.go
@@ -6,4 +6,5 @@ type MemberRepository interface {
 	FindById(id string) (domain.Member, error)
 	FindAll() ([]domain.Member, error)
 	New(member domain.Member) error
+	Update(member domain.Member) error
 }

--- a/usecase/member_repository.go
+++ b/usecase/member_repository.go
@@ -5,6 +5,6 @@ import "emoshu_practice/domain"
 type MemberRepository interface {
 	FindById(id string) (domain.Member, error)
 	FindAll() ([]domain.Member, error)
-	New(member domain.Member) error
+	New(member domain.Member) (domain.Member, error)
 	Update(member domain.Member) error
 }


### PR DESCRIPTION
## やったこと
・社員登録API作成
・社員情報更新API
・社員削除API

## 相談
今回のようなCreateメソッドは作成したデータはリクエストされたものをそのままレスポンスするのか、成功・失敗のみをレスポンスするのかどちらの方が慣習的に多いでしょうか？
リクエストされたデータをそのままレスポンスすると、↓の画像のように"id"や"created_at"が空のものが返却されます。それを防ぐためにsqlを実行してまうのも微妙な気がします、、、

## 動作確認
### 社員登録API
- READMEにしたがってcontainerを建てる
- READMEに従って初期データを挿入
- POSTでbodyパラメータを持たせてhttp://localhost:3000/api/membersにリクエスト
- [ ] ↓の画像のように作成した社員情報が返ればok
![スクリーンショット 2023-02-21 13 20 38](https://user-images.githubusercontent.com/125238522/220246890-e09487a1-b57f-4d6d-a53f-9751ec7d9945.png)

### 社員更新API
- READMEにしたがってcontainerを建てる
- READMEに従って初期データを挿入
- PUTでbodyパラメータを持たせてhttp://localhost:3000/api/members/{id}にリクエスト
- [ ] ↓の画像のように作成した社員情報が返ればok
![スクリーンショット 2023-02-22 17 45 56](https://user-images.githubusercontent.com/125238522/220568580-8acaf4b3-2ed6-4902-97e4-229da1e5b76c.png)


### 社員削除API
- READMEにしたがってcontainerを建てる
- READMEに従って初期データを挿入
- DELETEメソッドでクエリパラメータにidを持たせてhttp://localhost:3000/api/members/{id}にリクエスト
- [ ] ↓の画像のように作成した社員情報が返ればok
![スクリーンショット 2023-02-22 17 44 39](https://user-images.githubusercontent.com/125238522/220568268-74182b83-fade-4bab-af02-f371c73457b3.png)
